### PR TITLE
added support for scss versioning

### DIFF
--- a/src/public/main.module.js
+++ b/src/public/main.module.js
@@ -15,9 +15,6 @@ import 'file-loader?name=fonts/[name].[ext]!./fonts/bb-icons.svg';
 // images
 import './images/bb-logo.svg';
 
-// styles
-//import './main.scss';
-
 // chosen angular translations
 import 'file-loader?name=angular-i18n/[name].[ext]!bookingbug-angular/node_modules/angular-i18n/angular-locale_en.js';
 import 'file-loader?name=angular-i18n/[name].[ext]!bookingbug-angular/node_modules/angular-i18n/angular-locale_fr.js';

--- a/src/public/main.module.js
+++ b/src/public/main.module.js
@@ -16,7 +16,7 @@ import 'file-loader?name=fonts/[name].[ext]!./fonts/bb-icons.svg';
 import './images/bb-logo.svg';
 
 // styles
-import './main.scss';
+//import './main.scss';
 
 // chosen angular translations
 import 'file-loader?name=angular-i18n/[name].[ext]!bookingbug-angular/node_modules/angular-i18n/angular-locale_en.js';
@@ -25,6 +25,14 @@ import 'file-loader?name=angular-i18n/[name].[ext]!bookingbug-angular/node_modul
 import config from './main.config';
 import run from './main.run';
 import versionModule from './version/version.module';
+
+// Try to load a versioned scss file, otherwise load the default one
+try {
+    require('./main_v' + versioning.getUIVersion() + '.scss');
+} catch (ex) {
+    require('./main.scss');
+}
+
 
 export default angular
     .module('public', [

--- a/src/public/main.module.js
+++ b/src/public/main.module.js
@@ -27,8 +27,9 @@ import run from './main.run';
 import versionModule from './version/version.module';
 
 // Try to load a versioned scss file, otherwise load the default one
+import BBUIVersionService from 'bookingbug-angular/src/public-booking/-versioning/ui_version.service';
 try {
-    require('./main_v' + versioning.getUIVersion() + '.scss');
+    require('./main_v' + BBUIVersionService.getUIVersion() + '.scss');
 } catch (ex) {
     require('./main.scss');
 }

--- a/src/public/main_v2.scss
+++ b/src/public/main_v2.scss
@@ -1,0 +1,1 @@
+@import "~bookingbug-angular/src/public-booking/main_v2.scss";


### PR DESCRIPTION
The widget supports now scss versioning if you create a `main_v{version-number}.scss` file. 
It has a fallback to main.scss if anything goes wrong 